### PR TITLE
Fix taxonomy term display by using .LinkTitle

### DIFF
--- a/layouts/partials/page/meta.html
+++ b/layouts/partials/page/meta.html
@@ -26,7 +26,7 @@
       <ul class="ml-6 flex flex-row flex-wrap items-center space-x-2">
         {{- range . }}
           <li>
-            <a href="{{ .RelPermalink }}" class="taxonomy category">{{ .Name }}</a>
+            <a href="{{ .RelPermalink }}" class="taxonomy category">{{ .LinkTitle }}</a>
           </li>
         {{- end }}
       </ul>
@@ -43,7 +43,7 @@
       <ul class="not-prose ml-6 flex flex-row flex-wrap items-center space-x-2">
         {{- range . }}
           <li>
-            <a href="{{ .RelPermalink }}" class="taxonomy tag">{{ .Name }}</a>
+            <a href="{{ .RelPermalink }}" class="taxonomy tag">{{ .LinkTitle }}</a>
           </li>
         {{- end }}
       </ul>


### PR DESCRIPTION
This PR fixes an issue where taxonomy terms with special characters (e.g., "CI/CD") were incorrectly displayed due to the use of `.Name`.

Replacing it with `.LinkTitle` ensures that terms retain their original formatting.

### Example

![imagen](https://github.com/user-attachments/assets/a89beaea-8a88-4be8-95c0-a594c8b390ab)